### PR TITLE
Fix bug in CH5 Q7

### DIFF
--- a/chapter05.hs
+++ b/chapter05.hs
@@ -28,7 +28,7 @@ perfect :: Int -> [Int]
 perfect n = [x | x <- [1..n], (sum (factors x)) - x  == x]
 
 -- 7.
-exercise7 = concat [[(x,y) | x <- [1,2]] | y <- [3,4]]
+exercise7 = concat [[(x,y) | y <- [3,4]] | x <- [1,2]]
 
 -- 8.
 find :: Eq a => a -> [(a,b)] -> [b]


### PR DESCRIPTION
Question in the book is to remake this result:

```hs
Prelude> [(x,y) | x <- [1,2], y <- [3,4]]
[(1,3),(1,4),(2,3),(2,4)]
```

Current solution:
```hs
Prelude> concat [[(x,y) | x <- [1,2]] | y <- [3,4]]
[(1,3),(2,3),(1,4),(2,4)]
```

New solution:
```hs
Prelude> concat [[(x,y) | y <- [3,4]] | x <- [1,2]]
[(1,3),(1,4),(2,3),(2,4)]
```