### PR TITLE
Update chapter07.hs

### DIFF
--- a/chapter07.hs
+++ b/chapter07.hs
@@ -58,7 +58,7 @@ map' :: (a -> b) -> [a] -> [b]
 map' f = unfold (null) (f.head) (tail)
 
 iterate' :: (a -> a) -> a -> [a]
-iterate' f = unfold (\x -> False) (f) (f)
+iterate' f = unfold (\x -> False) (id) (f)
 
 -- 7.
 type Bit = Int


### PR DESCRIPTION
iterate function should behave as follows:
iterate f x = [x, f x, f (f x), ...]
What the solution here did was:
iterate' f x = [f x, f (f x), ...]

I updated it so that it behaves correctly